### PR TITLE
Reduce log level on LXC sample job

### DIFF
--- a/lxc.nomad
+++ b/lxc.nomad
@@ -7,7 +7,7 @@ job "example-lxc" {
       driver = "lxc"
 
       config {
-        log_level = "trace"
+        log_level = "info"
         verbosity = "verbose"
         template  = "/usr/share/lxc/templates/lxc-busybox"
       }


### PR DESCRIPTION
Trace logging is extremely noisy.  Closes #1 
